### PR TITLE
Updating Config File HUGO

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -48,13 +48,43 @@ enableRobotsTXT = true
   new_window = "Whether the link opens a new browser tab/window."
 
   [outputs]
-  home = ["HTML", "JSON"]
-  section = ["HTML", "JSON"]
-  taxonomy = ["HTML", "JSON"]
-
+  home = ["HTML","JSON"]
+  section = ["HTML","JSON"]
 
   [cms]
   [[cms.collections]]
+    name = "blog_post"
+    folder = "content/post/"
+    create = true
+    slug = "{{year}}-{{month}}-{{day}}-{{slug}}"
+
+    [[fields]]
+    label = "Author Name"
+    name = "author"
+    widget = "string"
+
+    [[fields]]
+    label = "Title"
+    name = "title"
+    widget = "string"
+
+    [[fields]]
+    label = "Date and Time"
+    name = "date"
+    widget = "datetime"
+
+    [[fields]]
+    label = "Blog Image"
+    name = "image"
+    widget = "image"
+
+    [[fields]]
+    label = "Blog Content"
+    name = "body"
+    widget = "markdown"
+
+
+
   # name = "blog"
   # label = "Blog"
   # folder = "content/blog"
@@ -64,33 +94,3 @@ enableRobotsTXT = true
   #   {label = "Date", name = "date", widget = "datetime"},
   #   {label = "Body", name = "body", widget = "markdown"}
   # ]
-
-  name = "blog_post"
-  folder = "content/post/"
-  create = true
-  slug = "{{year}}-{{month}}-{{day}}-{{slug}}"
-
-  [[fields]]
-  label = "Author Name"
-  name = "author"
-  widget = "string"
-
-  [[fields]]
-  label = "Title"
-  name = "title"
-  widget = "string"
-
-  [[fields]]
-  label = "Date and Time"
-  name = "date"
-  widget = "datetime"
-
-  [[fields]]
-  label = "Blog Image"
-  name = "image"
-  widget = "image"
-
-  [[fields]]
-  label = "Blog Content"
-  name = "body"
-  widget = "markdown"


### PR DESCRIPTION
# Changes:
- Updating HUGO config File.
- Removing   `taxonomy = ["HTML"]`  from the HUGO  config file and the reason because of the HUGO Version. 